### PR TITLE
Add optional title only for page title

### DIFF
--- a/content/blog/the-test-provider-pattern/index.md
+++ b/content/blog/the-test-provider-pattern/index.md
@@ -1,5 +1,6 @@
 ---
 title: The <TestProvider /> pattern
+htmlTitle: The TestProvider pattern
 date: '2019-04-17T18:00:00.284Z'
 description: How to make it easy to render your React components in your tests
 ---

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -15,7 +15,7 @@ class BlogPostTemplate extends React.Component {
         return (
             <Layout location={this.props.location} title={siteTitle}>
                 <SEO
-                    title={post.frontmatter.title}
+                    title={post.frontmatter.htmlTitle || post.frontmatter.title}
                     description={post.frontmatter.description || post.excerpt}
                 />
                 <h1>{post.frontmatter.title}</h1>
@@ -91,6 +91,7 @@ export const pageQuery = graphql`
             html
             frontmatter {
                 title
+                htmlTitle
                 date(formatString: "MMMM DD, YYYY")
                 description
                 originalPost


### PR DESCRIPTION
A title containing HTML tags will not be properly displayed `The <TestProvider /> pattern` becomes `The pattern`, so we add an optional title that will be instead used.